### PR TITLE
Delegate getValue/setValue in DefaultBuildContext to legacy build API

### DIFF
--- a/src/main/java/org/codehaus/plexus/build/DefaultBuildContext.java
+++ b/src/main/java/org/codehaus/plexus/build/DefaultBuildContext.java
@@ -153,12 +153,18 @@ public class DefaultBuildContext implements BuildContext {
 
     /** {@inheritDoc} */
     public Object getValue(String key) {
-        return contextMap.get(key);
+        if (isDefaultImplementation()) {
+            return contextMap.get(key);
+        }
+        return legacy.getValue(key);
     }
 
     /** {@inheritDoc} */
     public void setValue(String key, Object value) {
-        contextMap.put(key, value);
+        if (isDefaultImplementation()) {
+            contextMap.put(key, value);
+        }
+        legacy.setValue(key, value);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This prevents objects from being stored in the singleton DefaultBuildContext instead of the thread-local build context (ThreadBuildContext) in Eclipse, avoiding unintended cross-project state sharing.

Fix #107 