### PR TITLE
Establish an automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,13 @@ See the Apache License Version 2.0 for the specific language governing permissio
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.plexus.build</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
`org.codehaus.plexus.build` — the top-level package. Set through the `maven-jar-plugin` `manifestEntries`, the pattern plexus-utils uses and the rest of this sweep followed; see codehaus-plexus/plexus-xml#92.

The entry joins the `maven-jar-plugin` block already present for the `test-jar` execution rather than introducing a second one.

This was the last active jar-producing repo in the org without a stable module name. Master only — the `0.x` branch has had no commit since May 2023.

Verified: `jar --describe-module` reports

```
org.codehaus.plexus.build@1.2.1-SNAPSHOT automatic
contains org.codehaus.plexus.build
contains org.codehaus.plexus.build.connect
contains org.codehaus.plexus.build.connect.messages
```

*This change was created with AI assistance.*