### PR TITLE
Update parent to plexus 27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus</artifactId>
-    <version>26</version>
+    <version>27</version>
   </parent>
 
   <artifactId>plexus-build-api</artifactId>


### PR DESCRIPTION
Parent bump now that plexus 27 is on Central. It raises the build floor to Maven 3.9.0 and renames managed versions to `version.<artifactId>`; this project references none of the old names, so the bump is the whole change.

*This change was created with AI assistance.*