### PR TITLE
Bump plexus-utils to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>4.0.3</version>
+      <version>4.1.0</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>


### PR DESCRIPTION
plexus-utils 4.1.0 went out today. It stops excluding `.gitignore` and `.cvsignore` from `DirectoryScanner` by default, so this carries a behaviour change rather than only a version bump; the build is green locally.

*This change was created with AI assistance.*