### PR TITLE
Describe the artifact in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
   <artifactId>plexus-build-api</artifactId>
   <version>1.3.1-SNAPSHOT</version>
 
+  <name>Plexus Build API</name>
+  <description>An API that lets Maven plugins report file changes, messages and progress to whatever is
+    running the build, so an IDE can refresh what a plugin touched and show its diagnostics in place. Outside
+    an IDE the default implementation writes to the filesystem and the Maven log.</description>
+
   <scm>
     <connection>scm:git:https://github.com/codehaus-plexus/plexus-build-api.git</connection>
     <developerConnection>${project.scm.connection}</developerConnection>


### PR DESCRIPTION
Sonatype Central rejected the 1.3.0 bundle: the POM carried neither `name` nor `description`, and the portal does not accept them by inheritance. plexus-io hit the same thing and fixed it the same way before its 3.7.0 release.

Once this merges, 1.3.0 can be cut again — nothing from the failed attempt reached Central.

*This change was created with AI assistance.*