### PR TITLE
Draft the version the labels imply, not always a patch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,10 @@
+# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
+# Categories, labels and the version-resolver come from the shared org config.
+_extends: .github
+
+# Tags here are prefixed, so tag-prefix is what lets the drafter parse the
+# version out of the last tag. Without it the drafter reads what it can from the
+# tag string, and plexus-i18n once drafted 18.0.1 by finding the 18 in its name.
+tag-prefix: plexus-build-api-
+tag-template: plexus-build-api-$RESOLVED_VERSION
+name-template: $RESOLVED_VERSION


### PR DESCRIPTION
The drafter numbered every release in this repo as a patch, because `$NEXT_PATCH_VERSION` ignores the
version-resolver. `$RESOLVED_VERSION` reads it, so a PR labelled `enhancement` drafts a minor.

`tag-prefix` is the other half: without it the drafter parses the version out of the tag string as best it
can, which is how plexus-i18n came to draft `18.0.1` — it read the 18 out of its own name.

Depends on codehaus-plexus/.github#77, which makes the shared `name-template` resolve the same way.

*This change was created with AI assistance.*